### PR TITLE
Add support for letsencrypt TLS certificates

### DIFF
--- a/doc/host_vars.md
+++ b/doc/host_vars.md
@@ -27,8 +27,8 @@ Required in: `common`, `suricata`.
 
 Set to `true` or `false` (default). Defines whether LDAP authentication should
 check credentials against the `samba` organisational unit in the LDAP tree
-rather than the `mail` one. This option is only useful if you are also using the
-`samba` role.
+rather than the `mail` one. This option is only useful if you are also using
+the `samba` role.
 
 Optional in: `openvpn`
 
@@ -64,13 +64,13 @@ Required in: `backupninja`
 
 `backup_remote_ssh_keys`
 
-List of public SSH keys of the backup server, as they would appear in a
-SSH `known_hosts` file, listed following the YAML syntax, like for instance:
+List of public SSH keys of the backup server, as they would appear in a SSH
+`known_hosts` file, listed following the YAML syntax, like for instance:
 
     backup_remote_ssh_keys:
         - ssh-rsa AAAAB3NzaC1y....
-	- ssh-dss AAAAB3NzaC1kc...
-	- ecdsa-sha2-nistp256 AAAAE2Vj...
+        - ssh-dss AAAAB3NzaC1kc...
+        - ecdsa-sha2-nistp256 AAAAE2Vj...
 
 Required in: `backupninja`
 
@@ -139,8 +139,8 @@ Authentication mechanism for OpenVPN. Can be:
 - `tls` to authenticate clients with their TLS certificates;
 - `ldap` to authenticate clients with a login and password, against the
   locally-running OpenLDAP instance;
-- `both` to perform both authentication, in which case a connecting client needs
-  both a valid TLS certificate and valid credentials to connect.
+- `both` to perform both authentication, in which case a connecting client
+  needs both a valid TLS certificate and valid credentials to connect.
 
 Required in: `openvpn`
 
@@ -163,10 +163,9 @@ parameters are needed:
   `valid users` parameter
 - `caption` (defaults to `name`): comment of the shared drive;
 - `create_mask` (defaults to "0600"): default permissions for newly created
-    files in the given share
-- `directory_mask` (defaults to "0700"): default permissions for newly
-      created
-        directories in the given share
+  files in the given share
+- `directory_mask` (defaults to "0700"): default permissions for newly created
+  directories in the given share
 
 Example:
 
@@ -197,8 +196,8 @@ Required in: `suricata`
 
 The machine name of the administered server, e.g. "mycomputer".
 
-Required in: `ldap-account-manager`, `nginx`, `openvpn`, `prosody`, `roundcube`,
-`samba`, `tls`, `usermin`, `virtualmail`, `wordpress`
+Required in: `ldap-account-manager`, `nginx`, `openvpn`, `prosody`,
+`roundcube`, `samba`, `tls`, `usermin`, `virtualmail`, `wordpress`
 
 `tls_directory`
 
@@ -206,6 +205,19 @@ Local directory (on the machine running Ansible) where all the TLS files are
 stored (certificates, keys and Diffie-Hellmann parameters).
 
 Required in: `tls`
+
+`website_domain_name`
+
+The domain name of the website being served (often different to domain_name).
+
+Required in: `letsencrypt`
+
+`webmaster_email`
+
+The email address of the person responsible for web services (often different
+to admin_email)
+
+Required in: `letsencrypt`
 
 `wordpress_mysql_password`
 

--- a/doc/role-doc/letsencrypt.md
+++ b/doc/role-doc/letsencrypt.md
@@ -1,0 +1,56 @@
+# Summary
+
+## Description
+
+This role configures nginx to use certifiates isseud by Let's Encrypt instead
+of self-signed certificates installed by Caislean's TLS role. The advantage is
+that Let's Encrypt certificates are trusted by most browsers so visitors to
+your website won't see an untrusted certificate warning.
+
+## Notes
+
+More information about Let's Encrypt can be found here:
+https://letsencrypt.org/
+
+Use of this role implies acceptance of the Let's Encrypt Subscriber Agreement.
+This is available here: https://letsencrypt.org/repository/
+
+The Let's Encrypt role will only work on remote machines running Debian 8
+(Jessie) or later. This is because the Let's Encrypt client is only available
+in Debian Testing (stretch).
+
+This role adds the "testing" repository to the remote machine. The role also
+specifies apt preferences to make sure software is installed from the stable
+repositories unless explicitly specified otherwise.
+
+This role won't work unless `website_domain_name` resolves to the IP address of
+the remote machine. This is because Let's Encrypt verifies you control the
+demain for which you're requesting a certificate by placing a file in your
+webserver's webroot and then checking it can access that file from the domain
+in question.
+
+## Prerequired roles
+
+- `common`
+- `tls`
+- `nginx`
+
+# Manual steps
+
+# Configuration parameters (ansible variables)
+
+## Mandatory parameters
+
+### `website_domain_name`
+
+The domain name of the website you are serving from this machine (e.g.
+example.com)
+
+### `webmaster_email`
+
+The email address of the person responsible for administering the website (e.g.
+webmaster@example.com)
+
+## Optional parameters
+
+None.

--- a/doc/role-doc/letsencrypt.md
+++ b/doc/role-doc/letsencrypt.md
@@ -2,7 +2,8 @@
 
 ## Description
 
-This role configures nginx to use certifiates isseud by Let's Encrypt instead
+This role configures nginx to use certificates issued by [Let's
+Encrypt](https://letsencrypt.org/) instead
 of self-signed certificates installed by Caislean's TLS role. The advantage is
 that Let's Encrypt certificates are trusted by most browsers so visitors to
 your website won't see an untrusted certificate warning.
@@ -24,9 +25,9 @@ specifies apt preferences to make sure software is installed from the stable
 repositories unless explicitly specified otherwise.
 
 This role won't work unless `website_domain_name` resolves to the IP address of
-the remote machine. This is because Let's Encrypt verifies you control the
-demain for which you're requesting a certificate by placing a file in your
-webserver's webroot and then checking it can access that file from the domain
+the remote machine. This is because Let's Encrypt verifies that you control the
+domain for which you're requesting a certificate by placing a file in your
+webserver's webroot and then checking that it can access that file from the domain
 in question.
 
 ## Prerequired roles

--- a/doc/roles_list.md
+++ b/doc/roles_list.md
@@ -24,8 +24,9 @@ A list of all the roles that are necessary to run all or most of the services:
     *  `php-fpm`: PHP-FPM service and configuration for use with nginx and web
        services that require PHP;
     *  `mysql`: basic MySQL installation for use by web services;
-    *  `nginx`: basic nginx installation.
-
+    *  `nginx`: basic nginx installation;
+    *  `letsencrypt`: replacement TLS certificates from the Let's Encrypt
+       project - these are trusted by most modern browsers.
 
 ## Roles for the services
 

--- a/host_vars/caislean.domain.com
+++ b/host_vars/caislean.domain.com
@@ -2,6 +2,8 @@
  
 admin_email: user@domain.com
 domain_name: domain.com
+webmaster_email: webmaster@website.com
+website_domain_name: website.com
 server_name: caislean
 tls_directory: /home/user/caislean_admin/tls
 openvpn_auth_mech: tls

--- a/roles/letsencrypt/files/etc/apt/preferences.d/security.pref
+++ b/roles/letsencrypt/files/etc/apt/preferences.d/security.pref
@@ -1,0 +1,3 @@
+Package: *
+Pin: release l=Debian-Security
+Pin-Priority: 1000

--- a/roles/letsencrypt/files/etc/apt/preferences.d/stable.pref
+++ b/roles/letsencrypt/files/etc/apt/preferences.d/stable.pref
@@ -1,0 +1,3 @@
+Package: *
+Pin: release a=stable
+Pin-Priority: 900

--- a/roles/letsencrypt/files/etc/apt/preferences.d/testing.pref
+++ b/roles/letsencrypt/files/etc/apt/preferences.d/testing.pref
@@ -1,0 +1,3 @@
+Package: *
+Pin: release a=testing
+Pin-Priority: 750

--- a/roles/letsencrypt/handlers/main.yml
+++ b/roles/letsencrypt/handlers/main.yml
@@ -1,0 +1,4 @@
+---
+
+- name: restart nginx
+  service: name=nginx state=restarted

--- a/roles/letsencrypt/tasks/letsencrypt.yml
+++ b/roles/letsencrypt/tasks/letsencrypt.yml
@@ -36,8 +36,20 @@
   notify:
     - restart nginx
 
-- name: Add new nginx certificate configuration
+- name: Add new nginx private key configuration
   lineinfile: "dest=/etc/nginx/nginx.conf state=present insertbefore='ssl_dhparam' line='	ssl_certificate_key	/etc/letsencrypt/live/{{ website_domain_name }}/privkey.pem;'"
   tags: letsencrypt
   notify:
     - restart nginx
+
+# Try to renew the certificate daily, but keep the existing certificate unless it is due to be renewed.
+# Certificate renewals seem to fall due 10 days before expiry by default.
+- name: Schedule certificate renewals using cron
+  cron:
+  args:
+    cron_file: "ansible_letsencrypt_cert_renewal"
+    name: "letsencrypt renew certificate"
+    special_time: "daily"
+    user: "root"
+    job: "letsencrypt certonly --webroot --webroot-path /var/www/{{ server_name }}.{{ domain_name }} --email {{ webmaster_email }} -d {{ website_domain_name }} --agree-tos --keep && service nginx reload"
+  tags: letsencrypt

--- a/roles/letsencrypt/tasks/letsencrypt.yml
+++ b/roles/letsencrypt/tasks/letsencrypt.yml
@@ -1,0 +1,43 @@
+- name: Set apt preferences
+  copy: src=etc/apt/preferences.d/{{ item }} dest=/etc/apt/preferences.d/{{ item }} group=root owner=root
+  with_items:
+    - stable.pref
+    - security.pref
+    - testing.pref
+  tags: letsencrypt
+
+- name: Add testing Debian repository
+  apt_repository:
+  args:
+    repo: 'deb http://http.debian.net/debian stretch main'
+    state: present
+    update_cache: yes
+  tags: letsencrypt
+
+- name: Install letsencrypt client
+  apt: pkg=letsencrypt state=installed default_release=testing
+  tags: letsencrypt
+
+- name: Generate certificate for domain
+  command: "letsencrypt certonly --webroot --webroot-path /var/www/{{ server_name }}.{{ domain_name }} --email {{ webmaster_email }} -d {{ website_domain_name }} --agree-tos --keep"
+  tags: letsencrypt
+
+- name: Remove previous nginx certificate configuration
+  lineinfile: "dest=/etc/nginx/nginx.conf state=absent line='	ssl_certificate		/etc/ssl/certs/{{ server_name }}.{{ domain_name }}.pem;'"
+  tags: letsencrypt
+
+- name: Remove previous nginx private key configuration
+  lineinfile: "dest=/etc/nginx/nginx.conf state=absent line='	ssl_certificate_key	/etc/ssl/private/{{ server_name }}.{{ domain_name}}.key;'"
+  tags: letsencrypt
+
+- name: Add new nginx certificate configuration
+  lineinfile: "dest=/etc/nginx/nginx.conf state=present insertbefore='ssl_dhparam' line='	ssl_certificate		/etc/letsencrypt/live/{{ website_domain_name }}/fullchain.pem;'"
+  tags: letsencrypt
+  notify:
+    - restart nginx
+
+- name: Add new nginx certificate configuration
+  lineinfile: "dest=/etc/nginx/nginx.conf state=present insertbefore='ssl_dhparam' line='	ssl_certificate_key	/etc/letsencrypt/live/{{ website_domain_name }}/privkey.pem;'"
+  tags: letsencrypt
+  notify:
+    - restart nginx

--- a/roles/letsencrypt/tasks/main.yml
+++ b/roles/letsencrypt/tasks/main.yml
@@ -1,0 +1,2 @@
+- include: letsencrypt.yml
+  when: ansible_distribution_release == "jessie"

--- a/roles/nginx/files/etc/nginx/sites-available/000-default
+++ b/roles/nginx/files/etc/nginx/sites-available/000-default
@@ -14,8 +14,8 @@ server {
 }
 
 server {
-	listen   443 ssl default;
-	listen	[::]:443 ssl default ipv6only=on;
+	listen   443 ssl default_server;
+	listen	[::]:443 ssl default_server ipv6only=on;
 	server_name _;
 
 	expires -1;

--- a/roles/nginx/files/etc/nginx/sites-available/000-default
+++ b/roles/nginx/files/etc/nginx/sites-available/000-default
@@ -1,6 +1,6 @@
 server {
-	listen	80 default;
-	listen	[::]:80	default ipv6only=on;
+	listen	80 default_server;
+	listen	[::]:80	default_server ipv6only=on;
 	server_name _;
 
 	expires -1;


### PR DESCRIPTION
This role generates and installs TLS certificates from Let's Encrypt.
It also reconfigures nginx to use these instead of the self-signed
certificates generated by the `TLS` role.

Details
- Configure apt preferences to prefer stable over testing
- Add Debian testing repository
- Install letsencrypt client from testing repository
- Generate letsencrypt certificates for a single website
- Configure nginx to use letsencrypt certificates for that site
- Add role documentation

Bugfixes
- Fix incorrect nginx default_server specification
- Minor text re-wrapping in host_vars.md

To do
- Multiple site support
