### PR TITLE
Add missing step when configuring WP auth against LDAP

### DIFF
--- a/doc/role-doc/wordpress.md
+++ b/doc/role-doc/wordpress.md
@@ -54,6 +54,7 @@ If you wish to allow the LDAP users to log into Wordpress, you can use the
   Settings menu
 - configure the plugin as follows:
     - select "Yes" to "Enable Directory Authentication"
+    - select "Yes" to "Automatically Register Authenticated Users"
     - input `localhost` in "Directory Servers"
     - write `mail` in "Account Filter"
     - write `ou=mail,dc=example,dc=org` (change this according to your domain


### PR DESCRIPTION
If the plugin isn't configured to create new accounts for LDAP users on first login, they can't log in, and it just looks like they've typed in their password wrongly instead.
