### PR TITLE
Enable gzipping for not only 'text/html'

### DIFF
--- a/roles/nginx/templates/jessie-nginx.conf.j2
+++ b/roles/nginx/templates/jessie-nginx.conf.j2
@@ -63,6 +63,16 @@ http {
 
 	gzip on;
 	gzip_disable	"MSIE [1-6]\.(?!.*SV1)";
+	gzip_types
+                text/plain
+                text/css
+                text/xml
+                text/javascript
+                application/json
+                application/javascript
+                application/x-javascript
+                application/xml
+                application/xml+rss;
 
 	##
 	# Virtual Host Configs


### PR DESCRIPTION
http://nginx.org/en/docs/http/ngx_http_gzip_module.html#gzip_types

Enables gzipping of responses for the specified MIME types in addition to “text/html”. The special value “*” matches any MIME type (0.8.29). Responses with the “text/html” type are always compressed.
