### PR TITLE
Support multiple websites

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+site.retry
 site.yml
 ansible_hosts
 *.pyc

--- a/doc/role-doc/letsencrypt.md
+++ b/doc/role-doc/letsencrypt.md
@@ -3,10 +3,10 @@
 ## Description
 
 This role configures nginx to use certificates issued by [Let's
-Encrypt](https://letsencrypt.org/) instead
-of self-signed certificates installed by Caislean's TLS role. The advantage is
-that Let's Encrypt certificates are trusted by most browsers so visitors to
-your website won't see an untrusted certificate warning.
+Encrypt](https://letsencrypt.org/) instead of self-signed certificates
+installed by Caislean's TLS role. The advantage is that Let's Encrypt
+certificates are trusted by most browsers so visitors to your website won't see
+an untrusted certificate warning.
 
 ## Notes
 
@@ -24,11 +24,11 @@ This role adds the "testing" repository to the remote machine. The role also
 specifies apt preferences to make sure software is installed from the stable
 repositories unless explicitly specified otherwise.
 
-This role won't work unless `website_domain_name` resolves to the IP address of
-the remote machine. This is because Let's Encrypt verifies that you control the
-domain for which you're requesting a certificate by placing a file in your
-webserver's webroot and then checking that it can access that file from the domain
-in question.
+This role won't work unless every domain listed in `websites` resolves to the
+IP address of the remote machine. This is because Let's Encrypt verifies that
+you control the domains for which you're requesting certificates by placing
+files in each virtual host's webroot and then checking that it can access those
+files from the domains in question.
 
 ## Prerequired roles
 
@@ -36,16 +36,28 @@ in question.
 - `tls`
 - `nginx`
 
-# Manual steps
-
 # Configuration parameters (ansible variables)
 
 ## Mandatory parameters
 
-### `website_domain_name`
+### `websites`
 
-The domain name of the website you are serving from this machine (e.g.
-example.com)
+A list of domain names for which Caislean should generate certificates. This is
+the same list used by the `nginx` role when creating virtual hosts to serve.
+
+Default:
+
+websites:
+  - "{{ server_name }}.{{ domain_name }}"
+
+Add or change lines to create new nginx virtual hosts and generate letsencrypt
+certificates for them.
+
+Example:
+
+websites:
+ - "{{ domain_name }}"
+ - "www.example.com"
 
 ### `webmaster_email`
 

--- a/host_vars/caislean.domain.com
+++ b/host_vars/caislean.domain.com
@@ -1,10 +1,10 @@
 ---
- 
-admin_email: user@domain.com
-domain_name: domain.com
-webmaster_email: webmaster@website.com
-website_domain_name: website.com
 server_name: caislean
+domain_name: domain.com
+admin_email: "user@{{ domain_name }}"
+webmaster_email: "webmaster@{{ domain_name }}"
+websites:
+  - "{{ server_name }}.{{ domain_name }}"
 tls_directory: /home/user/caislean_admin/tls
 openvpn_auth_mech: tls
 auth_use_samba: false
@@ -32,4 +32,3 @@ dkim_directory: /home/user/sec_comms_admin/dkim
 mysql_root_password: MySQLPass
 owncloud_mysql_password: OwncloudPass
 wordpress_mysql_password: WordpressPass
-wordpress_ldap_auth: true

--- a/roles/letsencrypt/tasks/letsencrypt.yml
+++ b/roles/letsencrypt/tasks/letsencrypt.yml
@@ -1,43 +1,44 @@
 - name: Set apt preferences
-  copy: src=etc/apt/preferences.d/{{ item }} dest=/etc/apt/preferences.d/{{ item }} group=root owner=root
+  copy:
+    src: "etc/apt/preferences.d/{{ item }}"
+    dest: "/etc/apt/preferences.d/{{ item }}"
+    group: root
+    owner: root
   with_items:
     - stable.pref
     - security.pref
     - testing.pref
   tags: letsencrypt
 
-- name: Add testing Debian repository
+- name: Add Debian testing repository
   apt_repository:
-  args:
-    repo: 'deb http://http.debian.net/debian stretch main'
+    repo: "deb http://http.debian.net/debian stretch main"
     state: present
     update_cache: yes
   tags: letsencrypt
 
 - name: Install letsencrypt client
-  apt: pkg=letsencrypt state=installed default_release=testing
+  apt:
+    pkg: letsencrypt
+    state: installed
+    default_release: testing
   tags: letsencrypt
 
-- name: Generate certificate for domain
-  command: "letsencrypt certonly --webroot --webroot-path /var/www/{{ server_name }}.{{ domain_name }} --email {{ webmaster_email }} -d {{ website_domain_name }} --agree-tos --keep"
+- name: Generate certificates for websites
+  command: "letsencrypt certonly --webroot --webroot-path /var/www/{{ item }} --email {{ webmaster_email }} -d {{ item }} --agree-tos --keep"
+  with_items:
+    - "{{ websites }}"
   tags: letsencrypt
 
-- name: Remove previous nginx certificate configuration
-  lineinfile: "dest=/etc/nginx/nginx.conf state=absent line='	ssl_certificate		/etc/ssl/certs/{{ server_name }}.{{ domain_name }}.pem;'"
-  tags: letsencrypt
-
-- name: Remove previous nginx private key configuration
-  lineinfile: "dest=/etc/nginx/nginx.conf state=absent line='	ssl_certificate_key	/etc/ssl/private/{{ server_name }}.{{ domain_name}}.key;'"
-  tags: letsencrypt
-
-- name: Add new nginx certificate configuration
-  lineinfile: "dest=/etc/nginx/nginx.conf state=present insertbefore='ssl_dhparam' line='	ssl_certificate		/etc/letsencrypt/live/{{ website_domain_name }}/fullchain.pem;'"
-  tags: letsencrypt
-  notify:
-    - restart nginx
-
-- name: Add new nginx private key configuration
-  lineinfile: "dest=/etc/nginx/nginx.conf state=present insertbefore='ssl_dhparam' line='	ssl_certificate_key	/etc/letsencrypt/live/{{ website_domain_name }}/privkey.pem;'"
+- name: Configure nginx to use new certificates
+  template:
+    src: letsencrypt.j2
+    dest: "/etc/nginx/includes/{{ item }}/letsencrypt"
+    owner: root
+    group: root
+    mode: 0644
+  with_items:
+    - "{{ websites }}"
   tags: letsencrypt
   notify:
     - restart nginx
@@ -46,10 +47,12 @@
 # Certificate renewals seem to fall due 10 days before expiry by default.
 - name: Schedule certificate renewals using cron
   cron:
-  args:
-    cron_file: "ansible_letsencrypt_cert_renewal"
-    name: "letsencrypt renew certificate"
-    special_time: "daily"
-    user: "root"
-    job: "letsencrypt certonly --webroot --webroot-path /var/www/{{ server_name }}.{{ domain_name }} --email {{ webmaster_email }} -d {{ website_domain_name }} --agree-tos --keep && service nginx reload"
+    name: letsencrypt renew certificate
+    job: "letsencrypt certonly --webroot --webroot-path /var/www/{{ item }} --email {{ webmaster_email }} -d {{ item }} --agree-tos --keep && service nginx reload"
+    cron_file: "ansible_letsencrypt_{{ item }}_cert_renewal"
+    state: present
+    special_time: daily
+    user: root
+  with_items:
+    - "{{ websites }}"
   tags: letsencrypt

--- a/roles/letsencrypt/templates/letsencrypt.j2
+++ b/roles/letsencrypt/templates/letsencrypt.j2
@@ -1,0 +1,3 @@
+    add_header          Strict-Transport-Security max-age=63072000;
+    ssl_certificate     /etc/letsencrypt/live/{{ item }}/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/{{ item }}/privkey.pem;

--- a/roles/nginx/defaults/main.yml
+++ b/roles/nginx/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+
+websites:
+  - "{{ server_name }}.{{ domain_name }}"

--- a/roles/nginx/tasks/main.yml
+++ b/roles/nginx/tasks/main.yml
@@ -1,81 +1,159 @@
 - name: Install web server packages (from backports)
-  apt: pkg={{item}} state=installed default_release={{ansible_distribution_release}}-backports
+  apt:
+    pkg: "{{ item }}"
+    state: installed
+    default_release: "{{ansible_distribution_release}}-backports"
   with_items:
     - nginx
   when: ansible_distribution_release == "wheezy"
   tags: webserver
 
 - name: Install web server packages
-  apt: pkg={{item}} state=installed
+  apt:
+    pkg: "{{ item }}"
+    state: installed
   with_items:
     - nginx
   when: ansible_distribution_release == "jessie"
   tags: webserver
 
 - name: Create www group
-  group: name=www state=present
+  group:
+    name: www
+    state: present
   tags: webserver
 
 - name: Create www user
-  user: name=www group=www home=/var/www createhome=no shell=/bin/nologin
+  user:
+    name: www
+    group: www
+    home: /var/www
+    createhome: no
+    shell: /bin/nologin
   tags: webserver
 
 - name: Create nginx log directory
-  file: path={{item}} state=directory group=www owner=www mode=0750 recurse=no
+  file:
+    path: "{{ item }}"
+    state: directory
+    group: www
+    owner: www
+    mode: 0750
+    recurse: no
   with_items:
     - /var/log/nginx
   tags: webserver
 
 - name: Create nginx runtime directory
-  file: path={{item}} state=directory group=www owner=www mode=0750 recurse=no
+  file:
+    path: "{{ item }}"
+    state: directory
+    group: www
+    owner: www
+    mode: 0750
+    recurse: no
   with_items:
     - /var/run/nginx
   when: ansible_distribution_release == "wheezy"
   tags: webserver
 
 - name: Create nginx content directories
-  file: path={{item}} state=directory group=root owner=root mode=0755 recurse=no
+  file:
+    path: "/var/www/{{ item }}"
+    state: directory
+    group: root
+    owner: root
+    mode: 0755
+    recurse: no
   with_items:
-    - /var/www
-    - /var/www/default
-    - /var/www/{{ server_name }}.{{ domain_name }}
+    - default
+    - "{{ websites }}"
   tags: webserver
 
-- name: Create domain-specific directory in /etc/nginx/includes
-  file: path=/etc/nginx/includes/{{ server_name }}.{{ domain_name }} recurse=no state=directory owner=root group=root mode=0755
+- name: Add placeholder index.html file to document roots
+  template:
+    src: index.html.j2
+    dest: "/var/www/{{ item }}/index.html"
+    group: www
+    owner: www
+    mode: 0644
+  with_items:
+    - default
+    - "{{ websites }}"
+  tags: webserver
+
+- name: Create domain-specific directories in /etc/nginx/includes
+  file:
+    path: "/etc/nginx/includes/{{ item }}"
+    state: directory
+    owner: root
+    group: root
+    mode: 0755
+    recurse: no
+  with_items:
+    - "{{ websites }}"
   tags: webserver
 
 - name: Install nginx configuration
-  template: src={{ ansible_distribution_release }}-nginx.conf.j2 dest=/etc/nginx/nginx.conf
-  tags: webserver
-
-- name: Install custom default nginx virtual server
-  copy: src=etc/nginx/sites-available/000-default dest=/etc/nginx/sites-available/000-default owner=root group=root mode=0644
+  template:
+    src: "{{ ansible_distribution_release }}-nginx.conf.j2"
+    dest: /etc/nginx/nginx.conf
   tags: webserver
 
 - name: Disable old default nginx virtual server
-  file: path=/etc/nginx/sites-enabled/default state=absent
+  file:
+    path: /etc/nginx/sites-enabled/default
+    state: absent
+  tags: webserver
+
+- name: Install custom default nginx virtual server
+  copy:
+    src: etc/nginx/sites-available/000-default
+    dest: /etc/nginx/sites-available/000-default
+    owner: root
+    group: root
+    mode: 0644
   tags: webserver
 
 - name: Enable custom default nginx virtual server
-  file: path=/etc/nginx/sites-enabled/000-default state=link src=/etc/nginx/sites-available/000-default
+  file:
+    src: /etc/nginx/sites-available/000-default
+    path: /etc/nginx/sites-enabled/000-default
+    state: link
   tags: webserver
 
-- name: Install nginx virtual server specific to our server's hostname
-  template: src=nginx-vhost.j2 dest=/etc/nginx/sites-available/{{ server_name }}.{{ domain_name }} group=root owner=root mode=0644
+- name: Install nginx virtual servers
+  template:
+    src: nginx-vhost.j2
+    dest: "/etc/nginx/sites-available/{{ item }}"
+    group: root
+    owner: root
+    mode: 0644
+  with_items:
+    - "{{ websites }}"
   tags: webserver
 
-- name: Enable nginx virtual server
-  file: path=/etc/nginx/sites-enabled/{{ server_name }}.{{ domain_name }} state=link src=/etc/nginx/sites-available/{{ server_name }}.{{ domain_name }}
+- name: Enable nginx virtual servers
+  file:
+    src: "/etc/nginx/sites-available/{{ item }}"
+    path: "/etc/nginx/sites-enabled/{{ item }}"
+    state: link
+  with_items:
+    - "{{ websites }}"
   tags: webserver
 
 - name: Open HTTP and HTTPS ports in UFW (inbound)
-  ufw: rule=allow port={{item}} direction=in
+  ufw:
+    port: "{{ item }}"
+    rule: allow
+    direction: in
   tags: webserver, firewall
   with_items:
     - 80
     - 443
 
 - name: Force an nginx restart to pick up changes
-  service: name=nginx state=restarted
+  service:
+    name: nginx
+    state: restarted
   tags: webserver

--- a/roles/nginx/templates/index.html.j2
+++ b/roles/nginx/templates/index.html.j2
@@ -1,0 +1,21 @@
+<html>
+  <head>
+    <title>{{ item }}</title>
+    <style>
+      .container {
+        font-family: sans-serif;
+        position: absolute;
+        top: 50%;
+        left: 50%;
+        transform: translateX(-50%) translateY(-50%);
+      }
+    </style>
+  </head>
+  <body>
+  <div class="container">
+    <h1>Caislean left this space blank intentionally</h1>
+    <p>This is a placeholder index page for {{ item }}.</p>
+    <p>If you are the site administrator you should replace this page with your site's content.</p>
+  </div>
+  </body>
+</html>

--- a/roles/nginx/templates/jessie-nginx.conf.j2
+++ b/roles/nginx/templates/jessie-nginx.conf.j2
@@ -30,7 +30,6 @@ http {
 	# SSL Settings
 	##
 
-	add_header		Strict-Transport-Security max-age=63072000;
 	add_header		X-Frame-Options sameorigin;
 	add_header		X-Content-Type-Options nosniff;
 	add_header		X-XSS-Protection "1; mode=block";

--- a/roles/nginx/templates/nginx-vhost.j2
+++ b/roles/nginx/templates/nginx-vhost.j2
@@ -4,7 +4,7 @@ server {
 	listen	443 ssl;
 	listen	[::]:443 ssl;
 
-	server_name {{ server_name }}.{{ domain_name }};
+	server_name {{ item }};
 
 	expires -1;
 
@@ -13,7 +13,7 @@ server {
 		return 405;
 	}
 
-	root /var/www/{{ server_name }}.{{ domain_name }};
+	root /var/www/{{ item }};
 
-	include /etc/nginx/includes/{{ server_name }}.{{ domain_name }}/*;
+	include /etc/nginx/includes/{{ item }}/*;
 }

--- a/roles/nginx/templates/wheezy-nginx.conf.j2
+++ b/roles/nginx/templates/wheezy-nginx.conf.j2
@@ -26,7 +26,6 @@ http {
 
     gzip		on;
     gzip_disable	"MSIE [1-6]\.(?!.*SV1)";
-    add_header		Strict-Transport-Security max-age=63072000;
     add_header		X-Frame-Options sameorigin;
     add_header		X-Content-Type-Options nosniff;
     add_header		X-XSS-Protection "1; mode=block";


### PR DESCRIPTION
This branch resolves #68 by allowing Caislean users to specify an arbitrary number of websites to serve as nginx virtual hosts. 

It is possible to use the TLS role to generate a self-signed certificate that covers more than one website, however users must modify openssl.conf manually to specify additional domain names as Subject Alt
Names, and this is not yet documented.

Other changes included in this branch:
- Give sites a placeholder index.html file
- Reformat YAML to improve legibility
- Make letsencrypt role support multiple websites
- Use HSTS header only with trusted TLS certificates (closes #56)

Notes on issue #56:

Some browsers will refuse to allow security exceptions to be made for self-signed certificates when HSTS is configured. This commit removes HSTS from the nginx role by default and instead applies it on a per-domain basis when certificates are obtained from letsencrypt. The Let's Encrypt certificate authority is trusted by most browsers so it is safe to use HSTS with its certificates.
