### PR TITLE
Fix Ldap Account Manager role

### DIFF
--- a/doc/role-doc/ldap-account-manager.md
+++ b/doc/role-doc/ldap-account-manager.md
@@ -2,10 +2,8 @@
 
 ## Description
 
-This role installs and setups LDAP Account Manager, a web interface designed to
-fully administrate a LDAP tree.
-
-This role is currently broken.
+This role installs and sets up LDAP Account Manager, a web interface designed
+to administrate an LDAP tree.
 
 ## Prerequired roles
 
@@ -14,7 +12,25 @@ This role is currently broken.
 - `nginx`
 - `php-fpm`
 
-# Manual steps
+# Logging in
+
+Log in at the following URL using the credentials below.
+
+- URL: `https://server_name.domain_name/lam`
+- Username: `cn=admin,dc=domain_name,dc=tld`
+- Password: `ldap_admin_pass`
+
+Example:
+
+`server_name = caislean`
+`domain_name = example.com`
+`ldap_admin_pass = sekrit`
+
+With the above settings, the correct URL, username and password would be:
+
+- URL: `https://caislean.example.com/lam`
+- Username: `cn=admin,dc=example,dc=com`
+- Password: `sekrit`
 
 # Configuration parameters (ansible variables)
 

--- a/roles/ldap-account-manager/tasks/main.yml
+++ b/roles/ldap-account-manager/tasks/main.yml
@@ -1,72 +1,109 @@
 - name: Download ldap-account-manager (LAM) Debian package file
-  get_url: url=http://sourceforge.net/projects/lam/files/LAM/5.0/ldap-account-manager_5.0-1_all.deb dest=/root/ owner=root group=root mode=0644
-  tags:
-    - webldap
+  get_url:
+    url: http://sourceforge.net/projects/lam/files/LAM/5.3/ldap-account-manager_5.3-1_all.deb
+    dest: /root/
+    owner: root
+    group: root
+    mode: 0644
+  tags: webldap
 
 - name: Install LAM's dependencies (from backports)
-  apt: pkg={{item}} state=installed default_release={{ansible_distribution_release}}-backports
+  apt:
+    pkg: "{{ item }}"
+    state: installed
+    default_release: "{{ ansible_distribution_release }}-backports"
   with_items:
     - php5-imagick
     - php-fpdf
-  tags:
-    - webldap
+  tags: webldap
 
 - name: Install LAM
-  apt: deb=/root/ldap-account-manager_5.0-1_all.deb state=installed
-  tags:
-    - webldap
+  apt:
+    deb: /root/ldap-account-manager_5.3-1_all.deb
+    state: installed
+  tags: webldap
 
 - name: Add group lam
-  group: name=lam state=present
-  tags:
-    - webldap
+  group:
+    name: lam
+    state: present
+  tags: webldap
 
 - name: Add user lam
-  user: name=lam state=present group=lam shell="/bin/false" home=/usr/share/ldap-account-manager createhome=no password="*"
-  tags:
-    - webldap
+  user:
+    name: lam
+    state: present
+    group: lam
+    shell: "/bin/false"
+    home: /usr/share/ldap-account-manager
+    createhome: no
+    password: "*"
+  tags: webldap
 
 - name: Install LAM nginx configuration
-  template: src=nginx-ldap-account-manager.inc.j2 dest=/etc/nginx/includes/{{ server_name }}.{{ domain_name}}/ldap-account-manager owner=root group=root mode=0644
+  template:
+    src: nginx-ldap-account-manager.inc.j2
+    dest: "/etc/nginx/includes/{{ server_name }}.{{ domain_name}}/ldap-account-manager"
+    owner: root
+    group: root
+    mode: 0644
+  tags: webldap
   notify:
     - restart nginx
-  tags:
-    - webldap
 
 - name: Create PHP session directory for LAM
-  file: path=/var/lib/phpsession/ldap-account-manager state=directory owner=lam group=lam mode=0700 recurse=no
-  tags:
-    - webldap
+  file:
+    path: /var/lib/phpsession/ldap-account-manager
+    state: directory
+    owner: lam
+    group: lam
+    mode: 0700
+    recurse: no
+  tags: webldap
 
 - name: Copy LAM PHP configuration
-  copy: src=etc/php5/fpm/pool.d/ldap-account-manager.conf dest=/etc/php5/fpm/pool.d/ldap-account-manager.conf owner=root group=root mode=0644
+  copy:
+    src: etc/php5/fpm/pool.d/ldap-account-manager.conf
+    dest: /etc/php5/fpm/pool.d/ldap-account-manager.conf
+    owner: root
+    group: root
+    mode: 0644
+  tags: webldap
   notify:
     - restart php5-fpm
-  tags:
-    - webldap
 
 - name: Set correct ownership for /var/lib/ldap-account-manager/
-  file: path=/var/lib/ldap-account-manager state=directory group=root owner=lam recurse=yes
-  tags:
-    - webldap
+  file:
+    path: /var/lib/ldap-account-manager
+    state: directory
+    group: root
+    owner: lam
+    recurse: yes
+  tags: webldap
 
 - name: Retrieve hashed LDAP admin password
   command: slappasswd -s {{ ldap_admin_pass | quote }} -h '{SSHA}' -n
   register: slappasswd_hash
-  tags:
-    - webldap
+  tags: webldap
 
 - name: Set fact with hashed LDAP password
   set_fact: hashed_ldap_password="{{slappasswd_hash.stdout}}"
-  tags:
-    - webldap
+  tags: webldap
 
 - name: Copy LAM configuration to /etc/ldap-account-manager/
-  template: src=lam-config.cfg.j2 dest=/etc/ldap-account-manager/config.cfg group=root owner=lam mode=0600
-  tags:
-    - webldap
+  template:
+    src: lam-config.cfg.j2
+    dest: /etc/ldap-account-manager/config.cfg
+    group: root
+    owner: lam
+    mode: 0600
+  tags: webldap
 
 - name: Add 'caislean' profile for LAM
-  template: src=caislean-lam.conf.j2 dest=/var/lib/ldap-account-manager/config/caislean.conf group=root owner=lam mode=0600
-  tags:
-    - webldap
+  template:
+    src: caislean-lam.conf.j2
+    dest: /var/lib/ldap-account-manager/config/caislean.conf
+    group: root
+    owner: lam
+    mode: 0600
+  tags: webldap

--- a/roles/ldap-account-manager/templates/caislean-lam.conf.j2
+++ b/roles/ldap-account-manager/templates/caislean-lam.conf.j2
@@ -36,7 +36,7 @@ lamProMailReplyTo:
 lamProMailIsHTML: false
 lamProMailAllowAlternateAddress: true
 
-useTLS: yes
+useTLS: no
 followReferrals: false
 pagedResults: false
 accessLevel: 100


### PR DESCRIPTION
Pushing this now as a request for comments. So far I have:
- Reformatted the YAML for readability
- Reformat tags
- Made sure handlers get notified
- Upgraded to LAM v5.3-1
- Disabled TLS in LAM config (Since LAM connects to LDAP via localhost)
- Documented how to log into LAM

I've only tested this on Debian 8.

Still to do:
- Move role-specific settings (e.g. for Samba) to those roles, since
  users might not run all roles, and if some roles are missing users are
  asked to make unnecessary LDAP entries on login.
- Make adding user accounts easier by creating a profile that asks for
  just the required information. At the moment users must pick from a
  bewildering array of undocumented options.
