### PR TITLE
Nginx: allow multiple server names

### DIFF
--- a/roles/nginx/templates/nginx-vhost.j2
+++ b/roles/nginx/templates/nginx-vhost.j2
@@ -4,7 +4,7 @@ server {
 	listen	443 ssl;
 	listen	[::]:443 ssl;
 
-	server_name {{ item.name }};
+	server_name {{ item.name }} {{ item.aliases }};
 
 	expires -1;
 


### PR DESCRIPTION
The `name` variable is used for the root directory.
Hence the need of a second variable for the aliases

This however might be a problem with letsencrypt :/