### PR TITLE
Only include NginX vhost config files with the ``.conf`` extension

### DIFF
--- a/roles/nginx/templates/nginx-vhost.j2
+++ b/roles/nginx/templates/nginx-vhost.j2
@@ -14,5 +14,5 @@ server {
 
 	root /var/www/{{ item.name }};
 
-	include /etc/nginx/includes/{{ item.name }}/*;
+	include /etc/nginx/includes/{{ item.name }}/*.conf;
 }


### PR DESCRIPTION
This enables dropping other files under ``/etc/nginx/includes/VHOST`` like
password files that should not be read as NginX config files.