### PR TITLE
Bugfix: default SSH port does not take effect

### DIFF
--- a/roles/base-hardening/templates/jessie-sshd_config.j2
+++ b/roles/base-hardening/templates/jessie-sshd_config.j2
@@ -1,4 +1,4 @@
-Port {{ ansible_ssh_port if ansible_ssh_port is defined else 22 }}
+Port {{ ansible_ssh_port | default('22', true) }}
 Protocol 2
 HostKey /etc/ssh/ssh_host_rsa_key
 HostKey /etc/ssh/ssh_host_dsa_key

--- a/roles/base-hardening/templates/stretch-sshd_config.j2
+++ b/roles/base-hardening/templates/stretch-sshd_config.j2
@@ -1,4 +1,4 @@
-Port {{ ansible_ssh_port if ansible_ssh_port is defined else 22 }}
+Port {{ ansible_ssh_port | default('22', true) }}
 Protocol 2
 HostKey /etc/ssh/ssh_host_rsa_key
 HostKey /etc/ssh/ssh_host_dsa_key

--- a/roles/base-hardening/templates/wheezy-sshd_config.j2
+++ b/roles/base-hardening/templates/wheezy-sshd_config.j2
@@ -1,4 +1,4 @@
-Port {{ ansible_ssh_port if ansible_ssh_port is defined else 22 }}
+Port {{ ansible_ssh_port | default('22', true) }}
 Protocol 2
 HostKey /etc/ssh/ssh_host_rsa_key
 HostKey /etc/ssh/ssh_host_dsa_key


### PR DESCRIPTION
This commit fixes a bug where if the ansible_ssh_port parameter is not
specified explicitly (e.g. in the ansible_hosts file), the SSH port is
set to '' when the base-hardening role is run, which then prevents all
future access to the target machine.